### PR TITLE
Fix broken test at CI

### DIFF
--- a/bin/cli.js
+++ b/bin/cli.js
@@ -45,6 +45,7 @@ catch (e) {
   console.error("1st argument must be BASE64 digest of JSON")
   process.exit(1)
 }
+console.log(json)
 
 let opts
 try {

--- a/bin/cli.js
+++ b/bin/cli.js
@@ -45,12 +45,10 @@ catch (e) {
   console.error("1st argument must be BASE64 digest of JSON")
   process.exit(1)
 }
-console.log({json})
-console.error({json})
 
 let opts
 try {
-  opts = JSON.parse(json)
+  opts = JSON.parse(json.trim())
 }
 catch (e) {
   console.error("Given digested JSON was invalid.")

--- a/bin/cli.js
+++ b/bin/cli.js
@@ -45,7 +45,8 @@ catch (e) {
   console.error("1st argument must be BASE64 digest of JSON")
   process.exit(1)
 }
-console.log(json)
+console.log({json})
+console.error({json})
 
 let opts
 try {

--- a/test/bats/build.sh
+++ b/test/bats/build.sh
@@ -2,8 +2,8 @@
 set -ueo pipefail
 
 SCRIPTPATH="$( cd -- "$(dirname "$0")" >/dev/null 2>&1 ; pwd -P )"
-echo "SCRIPT PATH |$SCRIPTPATH|"
-echo "SCRIPT PATH |$SCRIPTPATH|" 1>&2
-PARSER=$(npm exec "$SCRIPTPATH/../../bin/cli.js" $(echo '{"command":"aclii.render.parser-tester","options":{"file":"'"$SCRIPTPATH"'/test.yml"}}' | base64))
+JSON=$(printf '{"command":"aclii.render.parser-tester","options":{"file":"%s/test.yml"}}' "$SCRIPTPATH")
+BASE64=$(echo "$JSON" | base64)
+PARSER=$(npm exec "$SCRIPTPATH/../../bin/cli.js" "$BASE64")
 echo "$PARSER"
 

--- a/test/bats/build.sh
+++ b/test/bats/build.sh
@@ -2,6 +2,8 @@
 set -ueo pipefail
 
 SCRIPTPATH="$( cd -- "$(dirname "$0")" >/dev/null 2>&1 ; pwd -P )"
+echo "SCRIPT PATH |$SCRIPTPATH|"
+echo "SCRIPT PATH |$SCRIPTPATH|" 1>&2
 PARSER=$(npm exec "$SCRIPTPATH/../../bin/cli.js" $(echo '{"command":"aclii.render.parser-tester","options":{"file":"'"$SCRIPTPATH"'/test.yml"}}' | base64))
 echo "$PARSER"
 

--- a/tmpl/test/parser-test.tmpl
+++ b/tmpl/test/parser-test.tmpl
@@ -1,0 +1,40 @@
+_aclii_debug () {
+  if [ -n "${ACLII_DEBUG+HAS_VALUE}" ]; then
+    echo "$@" >> /tmp/aclii-debug.log
+  fi
+}
+
+parse_test () {
+  argv=("$@")
+
+unset O_values
+unset O_wantType
+unset O_wantingObjectId
+unset O_argvMode
+unset O_cmd
+unset O_trailingArgs
+unset O_processed
+unset O_arg
+
+##// INCLUDE parser.tmpl
+
+# Path artifacts to global vars
+O_values=(${values[@]})
+O_wantType="$wantType"
+O_wantingObjectId="$wantingObjectId"
+O_argvMode="$argvMode"
+O_cmd="$cmd"
+O_trailingArgs=(${trailingArgs[@]})
+O_processed="$processed"
+O_arg="$arg"
+
+# Extract values
+# During test, no env-crashing name are given as param names I believe ;-)
+
+##// aclii.allCommands.forEach( c => {
+##//   c.ownOptions.forEach( o => {
+<%= o.name %>=${values[<%= o.id %>]}
+##//   })
+##// })
+
+}


### PR DESCRIPTION
I don't know why but this line
```
-PARSER=$(npm exec "$SCRIPTPATH/../../bin/cli.js" $(echo '{"command":"aclii.render.parser-tester","options":{"file":"'"$SCRIPTPATH"'/test.yml"}}' | base64))
```
has broken and extracted json looks like
```
{"command":"aclii.render.parser-tester","options":{"file":"'}
```

this type of string concatenation is illegal in some bash version?

I used `printf` instead, and will be careful about this style.